### PR TITLE
Create manifest-documents for collection objects as well.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ inherit_from: .rubocop_todo.yml
 require: rubocop-rspec
 
 AllCops:
+  TargetRubyVersion: 2.2
   Exclude:
     - 'Gemfile'
     - 'bin/**/*'

--- a/app/models/spotlight/resources/iiif_service.rb
+++ b/app/models/spotlight/resources/iiif_service.rb
@@ -19,11 +19,14 @@ module Spotlight
         @manifests ||= if manifest?
                          [create_iiif_manifest(object)]
                        else
-                         (object.try(:manifests) || []).map do |manifest|
-                           create_iiif_manifest(
+                         things = []
+                         things << create_iiif_manifest(object) if collection?
+                         (object.try(:manifests) || []).each do |manifest|
+                           things << create_iiif_manifest(
                              self.class.new(manifest['@id']).object
                            )
                          end
+                         things
                        end
       end
 
@@ -57,6 +60,10 @@ module Spotlight
 
       def manifest?
         object.is_a?(IIIF::Presentation::Manifest)
+      end
+
+      def collection?
+        object.is_a?(IIIF::Presentation::Collection)
       end
 
       def response

--- a/spec/models/spotlight/resources/iiif_harvester_spec.rb
+++ b/spec/models/spotlight/resources/iiif_harvester_spec.rb
@@ -22,7 +22,7 @@ describe Spotlight::Resources::IiifHarvester do
 
     it 'returns an Enumerator of all the solr documents' do
       expect(subject.to_solr).to be_a(Enumerator)
-      expect(subject.to_solr.count).to eq 4
+      expect(subject.to_solr.count).to eq 8
     end
 
     it 'all solr documents include exhibit context' do

--- a/spec/models/spotlight/resources/iiif_service_spec.rb
+++ b/spec/models/spotlight/resources/iiif_service_spec.rb
@@ -23,9 +23,9 @@ describe Spotlight::Resources::IiifService do
 
   describe '#manifests' do
     it 'returns manifests for the current service level' do
-      expect(subject.manifests.length).to eq 1
+      expect(subject.manifests.length).to eq 2
       expect(subject.manifests.first).to be_a Spotlight::Resources::IiifManifest
-      expect(subject.collections.first.manifests.length).to eq 1
+      expect(subject.collections.first.manifests.length).to eq 2
       expect(
         subject.collections.first.manifests.first
       ).to be_a Spotlight::Resources::IiifManifest
@@ -36,14 +36,13 @@ describe Spotlight::Resources::IiifService do
     let(:manifests) { described_class.parse(url) }
 
     it 'recursively traverses all all the collections and returns manifests' do
-      expect(manifests.count).to eq 4
       expect(manifests).to be_all do |manifest|
         manifest.is_a?(Spotlight::Resources::IiifManifest)
       end
     end
 
-    pending 'returns manifests representing collection documents' do
-      expect(manifests.count).to eq 7 # 3 collections + 4 manifests
+    it 'returns manifests representing collection documents' do
+      expect(manifests.count).to eq 8
     end
   end
 end


### PR DESCRIPTION
NOTE: This will require projectblacklight/blacklight-gallery#32 to be merged and a BL-5 backported release because blacklight-gallery currently throws an error when the document does not have configured tile source field.

Closes #4 
