### PR TITLE
Index both types for custom field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,5 @@ end
 # END ENGINE_CART BLOCK
 
 gem 'blacklight-spotlight', github: 'projectblacklight/spotlight'
+
+gem 'factory_girl_rails', require: false

--- a/app/decorators/spotlight/resources/both_fields.rb
+++ b/app/decorators/spotlight/resources/both_fields.rb
@@ -1,0 +1,21 @@
+module Spotlight
+  module Resources
+    # Decorates a Custom Field to give an accessor for the alternate suffix.
+    class BothFields < SimpleDelegator
+      def alternate_field
+        field.gsub(/(.*)_.*$/, '\1'+ alternate_field_suffix)
+      end
+
+      private
+
+      def alternate_field_suffix
+        if field.ends_with?(Spotlight::Engine.config.solr_fields.string_suffix)
+          Spotlight::Engine.config.solr_fields.text_suffix
+        else
+          Spotlight::Engine.config.solr_fields.string_suffix
+        end
+      end
+    end
+
+  end
+end

--- a/app/models/spotlight/resources/iiif_manifest.rb
+++ b/app/models/spotlight/resources/iiif_manifest.rb
@@ -85,7 +85,9 @@ module Spotlight
 
         metadata.each_with_object({}) do |(key, value), hash|
           next unless (field = exhibit_custom_fields[key])
+          field = BothFields.new(field)
           hash[field.field] = value
+          hash[field.alternate_field] = value
         end
       end
 

--- a/spec/models/spotlight/resources/iiif_manifest_spec.rb
+++ b/spec/models/spotlight/resources/iiif_manifest_spec.rb
@@ -69,6 +69,21 @@ describe Spotlight::Resources::IiifManifest do
         expect(subject.to_solr['readonly_attribution_tesim']).to eq ['Attribution Data']
       end
 
+      it 'indexes both forms' do
+        expect(subject.to_solr['readonly_attribution_ssim']).to eq ['Attribution Data']
+      end
+
+      it 'indexes both forms when a vocab' do
+        subject.to_solr
+        field = Spotlight::CustomField.where(slug: "attribution").first!
+        field.field_type = "vocab"
+        field.save
+        exhibit.reload
+
+        expect(subject.to_solr['readonly_attribution_ssim']).to eq ['Attribution Data']
+        expect(subject.to_solr['readonly_attribution_tesim']).to eq ['Attribution Data']
+      end
+
       it 'includes the top-level description' do
         expect(subject.to_solr['readonly_description_tesim']).to eq ['A test IIIF manifest']
       end

--- a/spotlight-resources-iiif.gemspec
+++ b/spotlight-resources-iiif.gemspec
@@ -23,14 +23,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "iiif-presentation"
 
   spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency 'capybara'
-  spec.add_development_dependency 'factory_girl_rails'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
 #  spec.add_development_dependency 'poltergeist', '>= 1.5.0' # for js testing using phantomjs
   spec.add_development_dependency "coveralls"
-  spec.add_development_dependency 'rubocop', '~> 0.37.2'
+  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "riiif"


### PR DESCRIPTION
This was necessary for our first attempt at search-across, so that we could add configuration for a field to be searchable and in facets.
